### PR TITLE
Bump Ansible roles

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -138,5 +138,8 @@
     # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''
 
+    # TODO: Remove when playbook is upgraded to Python 3
+    omero_web_python3: false
+
 
 - include: omero/omero-web-patch-settings.yml

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -455,5 +455,9 @@
     # OMERO.server internal SSL (only used for Nginx <-> OMERO.server traffic)
     omero_server_websocket_internal_cert_params: '-subj "/C=UK/ST=Scotland/L=Dundee/O=OME/CN=localhost" -days 3650'
 
+    # TODO: Remove when playbook is upgraded to Python 3
+    omero_server_python3: false
+    omero_web_python3: false
+
 
 - include: omero/omero-web-patch-settings.yml

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -271,3 +271,6 @@
 
     # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''
+
+    # TODO: Remove when playbook is upgraded to Python 3
+    omero_server_python3: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -54,16 +54,16 @@
 
 # https://github.com/ome/ansible-role-omero-server/pull/40
 - name: ome.omero_server
-  src: https://github.com/ome/ansible-role-omero-server/archive/19747f05bba640df9f562fd95b1cae655ebe8e0c.tar.gz
-  version: 19747f05bba640df9f562fd95b1cae655ebe8e0c
+  src: https://github.com/ome/ansible-role-omero-server/archive/5e26aa5c66c1b45ddbcd16151214ffcf024cff08.tar.gz
+  version: 5e26aa5c66c1b45ddbcd16151214ffcf024cff08
 
 - src: ome.omero_user
   version: 0.1.2
 
 # https://github.com/ome/ansible-role-omero-web/pull/26
 - name: ome.omero_web
-  src: https://github.com/ome/ansible-role-omero-web/archive/c24baed1476b08b9dc49fa26f359d6b72447d81b.tar.gz
-  version: c24baed1476b08b9dc49fa26f359d6b72447d81b
+  src: https://github.com/ome/ansible-role-omero-web/archive/b31b08897b28d35e2c657439925f920c13f96886.tar.gz
+  version: b31b08897b28d35e2c657439925f920c13f96886
 
 - src: ome.omero_web_apps
   version: 0.2.0


### PR DESCRIPTION
Sets `omero_server_python3: false` `omero_web_python3: false` for other OMERO servers so https://github.com/ome/prod-playbooks/pull/225 can be merged without waiting for other servers to be updated